### PR TITLE
Limit size of output buffer for decompression

### DIFF
--- a/lambda/app.py
+++ b/lambda/app.py
@@ -12,7 +12,8 @@ def handler(event, context):
     try:
         if event.get('headers', {}).get('content-encoding') == 'application/zstd':
             if event.get('isBase64Encoded', False):
-                body = dctx.decompress(base64.b64decode(event["body"])).decode('utf-8')
+                # Limit output buffer to 16MB
+                body = dctx.decompress(base64.b64decode(event["body"]), max_output_size=16*1024*1024).decode('utf-8')
         else:
             body = event["body"]
         ps = subprocess.run(CMD, text=True, cwd=CWD, check=False, stdout=subprocess.PIPE,


### PR DESCRIPTION
as per https://python-zstandard.readthedocs.io/en/latest/decompressor.html