### PR TITLE
refactor: update Dockerfile and source files for webkitgtk integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,40 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04 AS build
+
+# Snapshot base-image lib filenames BEFORE installing anything,
+# so we can later skip copying libs the runtime stage already has.
+RUN find /lib /usr/lib -maxdepth 3 -name '*.so*' -printf '%f\n' \
+  | sort -u > /tmp/base-libs.txt
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-  apt-get -qq install libwpewebkit-1.0-dev build-essential
+  apt-get -qq install --no-install-recommends \
+  build-essential \
+  libwebkitgtk-6.0-dev
 
-COPY . /opt/webkit-content-filter-validator
+COPY . /src
+WORKDIR /src
 
-WORKDIR /opt/webkit-content-filter-validator
+# Build the binary, then export only the shared libraries it links to
+# that are NOT already shipped in the runtime base image.
+RUN make webkit-content-filter-validator && \
+  mkdir /export && \
+  ldd webkit-content-filter-validator \
+  | awk '/=>/ && $3 ~ /^\// {print $3}' \
+  | while read lib; do \
+  name=$(basename "$lib"); \
+  grep -qFx "$name" /tmp/base-libs.txt \
+  || cp -L "$lib" /export/; \
+  done
 
-RUN make webkit-content-filter-validator
 
-CMD /opt/webkit-content-filter-validator/webkit-content-filter-validator
+FROM ubuntu:24.04
+
+COPY --from=build /export/ /usr/local/lib/
+COPY --from=build /src/webkit-content-filter-validator /usr/local/bin/
+
+# Refresh /etc/ld.so.cache so the dynamic linker sees the libs we just added.
+RUN ldconfig
+
+WORKDIR /tmp
+USER 1001:1001
+
+CMD ["/usr/local/bin/webkit-content-filter-validator"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = `pkg-config --cflags --libs wpe-webkit-1.0`
+CFLAGS = `pkg-config --cflags --libs webkitgtk-6.0`
 
 all: webkit-content-filter-validator compile_flags.txt
 

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -2,18 +2,22 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE}
 
+USER root
+
 ARG FUNCTION_DIR=/var/task/
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update &&\
   apt-get -qq install python3-pip curl
 
 RUN pip3 install --target ${FUNCTION_DIR} awslambdaric zstandard==0.22.0 &&\
-    curl -Lo /usr/local/bin/aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie &&\
-    chmod +x /usr/local/bin/aws-lambda-rie
+  curl -Lo /usr/local/bin/aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie &&\
+  chmod +x /usr/local/bin/aws-lambda-rie
 
 COPY * ${FUNCTION_DIR}
 
 WORKDIR ${FUNCTION_DIR}
+
+USER 1001:1001
 
 ENTRYPOINT [ "./ric.sh" ]
 

--- a/lambda/app.py
+++ b/lambda/app.py
@@ -2,7 +2,7 @@ import subprocess
 import base64
 import zstandard as zstd
 
-CMD = ["/opt/webkit-content-filter-validator/webkit-content-filter-validator"]
+CMD = ["/usr/local/bin/webkit-content-filter-validator"]
 CWD = "/tmp"  # binary creates temp files, only /tmp is writeable to its UID
 SUCCESS = 0
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,4 @@
-#include <wpe/webkit.h>
+#include <webkit/webkit.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
- Changed base image from ubuntu:22.04 to ubuntu:24.04.
- Updated library dependencies in Dockerfile to use libwebkitgtk-6.0.
- Modified Makefile to reflect the new library flags.
- Updated source code to include the correct webkit header files.